### PR TITLE
Fix pickables falling in holes even when hooked

### DIFF
--- a/items/hookshot.lua
+++ b/items/hookshot.lua
@@ -376,6 +376,7 @@ function item:on_using()
       if not hooked and not going_back then
         entities_cought[#entities_cought + 1] = entity
         entity:set_position(hookshot:get_position())
+        hookshot:set_modified_ground("traversable")  -- Don't let the cought entity fall in holes.
         go_back()
       end
 


### PR DESCRIPTION
Another fix for the scripted hookshot.
